### PR TITLE
Datadog stateless tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,9 @@
 ---
-language: python
-python: "2.7"
-
-# Use the new container infrastructure
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
-
-install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
-  
-  # Check ansible version
-  - ansible --version
+services:
+  - docker
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - ./test.sh
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:2.7
+
+WORKDIR /opt
+
+RUN pip install ansible ansible-lint && \
+    printf '[defaults]\nroles_path=../' >ansible.cfg
+
+COPY . .

--- a/files/notify_updates
+++ b/files/notify_updates
@@ -22,9 +22,6 @@ if [ "JENKINS_JOB_NAME" == '%JENKINS_JOB_NAME_TEMPLATE%' ]; then
     exit 0
 fi
 
-metadata_url='http://169.254.169.254/latest/dynamic/instance-identity/document'
-region=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/\(.*\)./\1/')
-
 if [ -z "STATELESS_INSTANCE" ]; then
     echo 'STATELESS_INSTANCE should be set to 0 or 1' >&1
 fi

--- a/files/notify_updates
+++ b/files/notify_updates
@@ -1,32 +1,32 @@
 #!/bin/bash
 
-set -e
+set -eou pipefail
 
-if [ -z "DATADOG_API_TOKEN" ]; then
+if [ -z "${DATADOG_API_TOKEN}" ]; then
     echo 'DATADOG_API_TOKEN must be set' >&1
     exit 1
 fi
 
-if [ "DATADOG_API_TOKEN" == '%DATADOG_API_KEY_TEMPLATE%' ]; then
+if [ "${DATADOG_API_TOKEN}" == '%DATADOG_API_KEY_TEMPLATE%' ]; then
     echo 'DATADOG_API_TOKEN contains placeholder, ignoring' >&1
     exit 0
 fi
 
-if [ -z "JENKINS_JOB_NAME" ]; then
+if [ -z "${JENKINS_JOB_NAME}" ]; then
     echo 'JENKINS_JOB_NAME must be set' >&1
     exit 1
 fi
 
-if [ "JENKINS_JOB_NAME" == '%JENKINS_JOB_NAME_TEMPLATE%' ]; then
+if [ "${JENKINS_JOB_NAME}" == '%JENKINS_JOB_NAME_TEMPLATE%' ]; then
     echo 'JENKINS_JOB_NAME contains placeholder, ignoring' >&1
     exit 0
 fi
 
-if [ -z "STATELESS_INSTANCE" ]; then
+if [ -z "${STATELESS_INSTANCE}" ]; then
     echo 'STATELESS_INSTANCE should be set to 0 or 1' >&1
 fi
 
 updates="$(/usr/sbin/yum-cron /etc/yum/yum-cron-notify.conf)"
-if [[ ! -z "$updates" ]]; then
+if [[ -n "${updates}" ]]; then
     /usr/local/bin/send_datadog_event.py "${updates}"
 fi

--- a/files/notify_updates
+++ b/files/notify_updates
@@ -25,6 +25,10 @@ fi
 metadata_url='http://169.254.169.254/latest/dynamic/instance-identity/document'
 region=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/\(.*\)./\1/')
 
+if [ -z "STATELESS_INSTANCE" ]; then
+    echo 'STATELESS_INSTANCE should be set to 0 or 1' >&1
+fi
+
 updates="$(/usr/sbin/yum-cron /etc/yum/yum-cron-notify.conf)"
 if [[ ! -z "$updates" ]]; then
     /usr/local/bin/send_datadog_event.py "${updates}"

--- a/files/send_datadog_event.py
+++ b/files/send_datadog_event.py
@@ -12,11 +12,16 @@ def main(argv):
     updates = argv[0]
     jenkins_job_name = os.getenv('JENKINS_JOB_NAME')
 
+    stateless = bool(os.getenv('STATELESS_INSTANCE', 1))
+
     initialize(**options)
 
     title = "Software Update!"
     text = 'update-notifier (yum-cron) has flagged the following updates \n{}'.format(updates)
-    tags = ['job:{}'.format(jenkins_job_name)]
+    tags = [
+        'job:{}'.format(jenkins_job_name),
+        'stateless:{}'.format(stateless),
+    ]
 
     api.Event.create(title=title, text=text, tags=tags)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,20 +1,12 @@
 galaxy_info:
-  author: your name
-  description: your description
-  company: your company (optional)
+  author: Acuris
+  description: Installs files for sending software update notifications to Datadog
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
   # issue_tracker_url: http://example.com/issue/tracker
 
-  # Some suggested licenses:
-  # - BSD (default)
-  # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
-  license: none
+  license: MIT
 
   min_ansible_version: 1.2
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,7 @@
   yum:
     name: "{{ item }}"
   with_items:
-    - jq
     - yum-cron
-
-- name:
-  pip:
-    name: awscli
 
 - name: remove yum-cron hourly
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,12 +44,14 @@
     minute: 0
     job: "/usr/local/bin/notify_updates &>> /var/log/notify_updates.log"
 
-- cronvar:
+- name: Jenkins job name for API
+  cronvar:
     name: JENKINS_JOB_NAME
     value: "%JENKINS_JOB_NAME_TEMPLATE%"
     cron_file: notify_updates
 
-- cronvar:
+- name: Datadog API token
+  cronvar:
     name: DATADOG_API_TOKEN
     value: "%DATADOG_API_KEY_TEMPLATE%"
     cron_file: notify_updates

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+IMAGE_ID="$(basename $(pwd))"
+
+docker image build -t "${IMAGE_ID}" .
+
+docker container run --rm --name "${IMAGE_ID}" \
+    $(tty -s && echo -t) \
+    "${IMAGE_ID}" \
+    ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+docker container run --rm --name "${IMAGE_ID}" \
+    $(tty -s && echo -t) \
+    "${IMAGE_ID}" \
+    ansible-lint .
+
+docker container run --rm -it -v "$(pwd)":"$(pwd)" -w "$(pwd)" \
+    koalaman/shellcheck \
+    ./files/notify_updates


### PR DESCRIPTION
Send a `stateless` tag to Datadog - look for an environment variable (but don't fail if it's not there, just default to being `stateless:True`).

Add more tests and run them all inside Docker so that they're easier to run locally.